### PR TITLE
Specifying dependent python version to 2.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ message(STATUS "SWIG_FOUND = ${SWIG_FOUND}")
 message(STATUS "SWIG_USE_FILE = ${SWIG_USE_FILE}")
 include(${SWIG_USE_FILE})
 ### PythonLibs
-find_package(PythonLibs REQUIRED)
+find_package(PythonLibs 2.7 REQUIRED)
 message(STATUS "PYTHON_INCLUDE_DIR = ${PYTHON_INCLUDE_DIR}")
 include_directories(${PYTHON_INCLUDE_DIR})
 message(STATUS "PYTHON_LIBRARIES = ${PYTHON_LIBRARIES}")


### PR DESCRIPTION
This pull request specifies dependent python version to 2.7 explicitly in cmake process. CMake is possibly able to find different version of python (such as python 3.4, which is not compatible with 2.7) without this specification, and cause linking error.
